### PR TITLE
Create sales.xml

### DIFF
--- a/etc/sales.xml
+++ b/etc/sales.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Sales:etc/sales.xsd">
+    <order>
+        <available_product_type name="foggylinedailydeal"/>
+    </order>
+</config>


### PR DESCRIPTION
Missing configuration file for Magento_Sales module
Without it the products of this custom type will not show in the new order product grid
